### PR TITLE
CVE-2025-66478 mitigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "knex": "3.1.0",
                 "luxon": "3.7.2",
                 "morgan": "1.10.0",
-                "next": "16.0.6",
+                "next": "16.0.7",
                 "next-connect": "0.9.1",
                 "next-iron-session": "4.2.0",
                 "node-dijkstra": "2.5.0",
@@ -1766,9 +1766,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.6.tgz",
-            "integrity": "sha512-PFTK/G/vM3UJwK5XDYMFOqt8QW42mmhSgdKDapOlCqBUAOfJN2dyOnASR/xUR/JRrro0pLohh/zOJ77xUQWQAg==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.7.tgz",
+            "integrity": "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
@@ -1781,9 +1781,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.6.tgz",
-            "integrity": "sha512-AGzKiPlDiui+9JcPRHLI4V9WFTTcKukhJTfK9qu3e0tz+Y/88B7vo5yZoO7UaikplJEHORzG3QaBFQfkjhnL0Q==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.7.tgz",
+            "integrity": "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg==",
             "cpu": [
                 "arm64"
             ],
@@ -1797,9 +1797,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.6.tgz",
-            "integrity": "sha512-LlLLNrK9WCIUkq2GciWDcquXYIf7vLxX8XE49gz7EncssZGL1vlHwgmURiJsUZAvk0HM1a8qb1ABDezsjAE/jw==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.7.tgz",
+            "integrity": "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA==",
             "cpu": [
                 "x64"
             ],
@@ -1813,9 +1813,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.6.tgz",
-            "integrity": "sha512-r04NzmLSGGfG8EPXKVK72N5zDNnq9pa9el78LhdtqIC3zqKh74QfKHnk24DoK4PEs6eY7sIK/CnNpt30oc59kg==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.7.tgz",
+            "integrity": "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==",
             "cpu": [
                 "arm64"
             ],
@@ -1829,9 +1829,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.6.tgz",
-            "integrity": "sha512-hfB/QV0hA7lbD1OJxp52wVDlpffUMfyxUB5ysZbb/pBC5iuhyLcEKSVQo56PFUUmUQzbMsAtUu6k2Gh9bBtWXA==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.7.tgz",
+            "integrity": "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==",
             "cpu": [
                 "arm64"
             ],
@@ -1845,9 +1845,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.6.tgz",
-            "integrity": "sha512-PZJushBgfvKhJBy01yXMdgL+l5XKr7uSn5jhOQXQXiH3iPT2M9iG64yHpPNGIKitKrHJInwmhPVGogZBAJOCPw==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.7.tgz",
+            "integrity": "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==",
             "cpu": [
                 "x64"
             ],
@@ -1861,9 +1861,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.6.tgz",
-            "integrity": "sha512-LqY76IojrH9yS5fyATjLzlOIOgwyzBuNRqXwVxcGfZ58DWNQSyfnLGlfF6shAEqjwlDNLh4Z+P0rnOI87Y9jEw==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.7.tgz",
+            "integrity": "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==",
             "cpu": [
                 "x64"
             ],
@@ -1877,9 +1877,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.6.tgz",
-            "integrity": "sha512-eIfSNNqAkj0tqKRf0u7BVjqylJCuabSrxnpSENY3YKApqwDMeAqYPmnOwmVe6DDl3Lvkbe7cJAyP6i9hQ5PmmQ==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.7.tgz",
+            "integrity": "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1893,9 +1893,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.6.tgz",
-            "integrity": "sha512-QGs18P4OKdK9y2F3Th42+KGnwsc2iaThOe6jxQgP62kslUU4W+g6AzI6bdIn/pslhSfxjAMU5SjakfT5Fyo/xA==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.7.tgz",
+            "integrity": "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug==",
             "cpu": [
                 "x64"
             ],
@@ -7764,12 +7764,12 @@
             "license": "MIT"
         },
         "node_modules/next": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/next/-/next-16.0.6.tgz",
-            "integrity": "sha512-2zOZ/4FdaAp5hfCU/RnzARlZzBsjaTZ/XjNQmuyYLluAPM7kcrbIkdeO2SL0Ysd1vnrSgU+GwugfeWX1cUCgCg==",
+            "version": "16.0.7",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
+            "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "16.0.6",
+                "@next/env": "16.0.7",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
@@ -7782,14 +7782,14 @@
                 "node": ">=20.9.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "16.0.6",
-                "@next/swc-darwin-x64": "16.0.6",
-                "@next/swc-linux-arm64-gnu": "16.0.6",
-                "@next/swc-linux-arm64-musl": "16.0.6",
-                "@next/swc-linux-x64-gnu": "16.0.6",
-                "@next/swc-linux-x64-musl": "16.0.6",
-                "@next/swc-win32-arm64-msvc": "16.0.6",
-                "@next/swc-win32-x64-msvc": "16.0.6",
+                "@next/swc-darwin-arm64": "16.0.7",
+                "@next/swc-darwin-x64": "16.0.7",
+                "@next/swc-linux-arm64-gnu": "16.0.7",
+                "@next/swc-linux-arm64-musl": "16.0.7",
+                "@next/swc-linux-x64-gnu": "16.0.7",
+                "@next/swc-linux-x64-musl": "16.0.7",
+                "@next/swc-win32-arm64-msvc": "16.0.7",
+                "@next/swc-win32-x64-msvc": "16.0.7",
                 "sharp": "^0.34.4"
             },
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "knex": "3.1.0",
         "luxon": "3.7.2",
         "morgan": "1.10.0",
-        "next": "16.0.6",
+        "next": "16.0.7",
         "next-connect": "0.9.1",
         "next-iron-session": "4.2.0",
         "node-dijkstra": "2.5.0",
@@ -61,6 +61,5 @@
         "ts-jest": "29.1.2",
         "ts-node": "9.1.1",
         "typescript": "5.7.3"
-    },
-    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+    }
 }


### PR DESCRIPTION
Bumps NextJS to 6.0.7 to mitigate severe CVE

- See https://nextjs.org/blog/CVE-2025-66478